### PR TITLE
fix: flip commit ordering in list and request-review commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ git commit -m "Add logout functionality"
 # See your patch stack
 glu ls
 # main → origin/main [↑2 ↓0]
-#   1  abc1234  Fix validation bug
-#   2  def5678  Add logout functionality
+#   2  abc1234  Fix validation bug
+#   1  def5678  Add logout functionality
 
 # Create PR for single patch
 glu rr 1

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -90,7 +90,7 @@ export async function listCommits() {
       return
     }
 
-    ;[...log.all].reverse().forEach((commit: any, index: number) => {
+    log.all.forEach((commit: any, index: number) => {
       const shortSha = commit.hash.substring(0, 7)
       const message =
         commit.subject.length > 60
@@ -98,7 +98,7 @@ export async function listCommits() {
           : commit.subject
 
       // Format with consistent spacing - 2 spaces before index, 2 spaces after index
-      const paddedIndex = (index + 1).toString().padStart(2)
+      const paddedIndex = (log.all.length - index).toString().padStart(2)
       console.log(
         `  ${chalk.cyan(paddedIndex)}  ${chalk.yellow(shortSha)}  ${message}`
       )

--- a/src/commands/request-review.ts
+++ b/src/commands/request-review.ts
@@ -101,7 +101,19 @@ export async function requestReview(
       return
     }
 
-    const allCommits = [...log.all].reverse() // oldest to newest
+    const allCommits = log.all
+
+    // Convert display indices to array indices (flip order: newest=1)
+    if (range.includes("-")) {
+      startIndex = allCommits.length - 1 - startIndex
+      endIndex = allCommits.length - 1 - endIndex
+      // Swap if needed since we flipped
+      if (startIndex > endIndex) {
+        ;[startIndex, endIndex] = [endIndex, startIndex]
+      }
+    } else {
+      startIndex = endIndex = allCommits.length - 1 - startIndex
+    }
 
     // Validate range
     if (

--- a/tests/e2e/commands/ls.test.ts
+++ b/tests/e2e/commands/ls.test.ts
@@ -82,8 +82,21 @@ describe("glu ls", () => {
     expect(result.stdout).toContain(
       `${currentBranch} → origin/${currentBranch}`
     )
-    expect(result.stdout).toContain("[↑2 ↓0]") // 2 behind because we have newer commits on current branch
-    expect(result.stdout).toContain("Add feature")
-    expect(result.stdout).toContain("Fix feature")
+
+    const log = await git.log()
+    const commits = log.all
+
+    const lines = result.stdout.split("\n").filter(Boolean)
+    expect(lines[0]).toEqual("master → origin/master [↑2 ↓0]")
+
+    // Assess structure of lines
+    expect(lines[1]).toMatch(/^\s+2\s+[a-f0-9]{7}\s+.+$/)
+    expect(lines[2]).toMatch(/^\s+1\s+[a-f0-9]{7}\s+.+$/)
+
+    // Assess line content accurracy
+    expect(lines[1]).toContain(commits[0]?.message) // newest commit
+    expect(lines[1]).toContain(commits[0]?.hash.substring(0, 7))
+    expect(lines[2]).toContain(commits[1]?.message) // older commit
+    expect(lines[2]).toContain(commits[1]?.hash.substring(0, 7))
   })
 })


### PR DESCRIPTION
## Summary

Flips the commit ordering in both `glu ls` and `glu rr` commands so that the newest commits appear first with index 1, making the interface more intuitive and
consistent.

This means that the glu ls messages will show as follows:
```bash
main → origin/main [↑2 ↓0]

   2  fd9241b  add feature1
   1  e18bf21  fix: reverse number of glu ls
```

## Changes

- [ ] Added new feature
- [x] Fixed bug
- [ ] Updated documentation
- [ ] Added tests
- [x] Updated configuration

## Testing

- [ ] Tests pass locally (`npm run test:run`)
- [ ] Code is formatted (`npm run format:check`)
- [ ] Build succeeds (`npm run build`)
- [ ] Manual testing completed (if applicable)

## Notes

**Breaking Change:** This reverses the commit numbering in both list and request-review commands. Previously, index 1 referred to the oldest commit ahead of
origin. Now index 1 refers to the newest commit ahead of origin.

**Changes made:**
- Modified `src/commands/list.ts` to display newest commits first with index 1
- Updated `src/commands/request-review.ts` to use same ordering logic as list display

This makes the tool more intuitive as users by displaying as a stack
