### PR TITLE
chore: add tooling for test script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glu-cli",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glu-cli",
-      "version": "0.1.0-alpha.1",
+      "version": "0.1.0-alpha.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@octokit/rest": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "format:check": "prettier --check .",
     "preglu": "npm run --silent build",
     "glu": "node ./dist/index.js",
-    "glu-debug": "DEBUG=simple-git node ./dist/index.js"
+    "glu-debug": "DEBUG=simple-git node ./dist/index.js",
+    "dev:test-stack": "node scripts/create-test-stack.js"
   },
   "keywords": [
     "git",

--- a/scripts/create-test-stack.js
+++ b/scripts/create-test-stack.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import { simpleGit } from "simple-git"
+import fs from "fs-extra"
+import path from "path"
+import os from "os"
+import chalk from "chalk"
+
+// TODO: Use shared functionality from tests GitFixture. Will require creating a shared package
+async function createTestStack() {
+  const tempPath = await fs.mkdtemp(path.join(os.tmpdir(), "glu-manual-test-"))
+  const git = simpleGit(tempPath)
+
+  console.log(chalk.magenta(`Creating test stack in: ${tempPath}\n`))
+
+  await git.init()
+  await git.addConfig("user.name", "Test User")
+  await git.addConfig("user.email", "test@example.com")
+  await git.checkoutLocalBranch("main")
+
+  await fs.writeFile(path.join(tempPath, "README.md"), "# Test Project\n")
+  await git.add(".")
+  const result = await git.commit("Initial commit")
+
+  await git.addRemote("origin", "https://github.com/test/test-repo.git")
+  const refPath = path.join(tempPath, ".git", "refs", "remotes", "origin")
+  await fs.ensureDir(refPath)
+  await fs.writeFile(path.join(refPath, "main"), result.commit + "\n")
+  await git.addConfig("branch.main.remote", "origin")
+  await git.addConfig("branch.main.merge", "refs/heads/main")
+
+  await fs.writeFile(
+    path.join(tempPath, "feature-a.js"),
+    'export const featureA = () => "A";\n'
+  )
+  await git.add(".")
+  await git.commit("Add feature A")
+  await git.branch(["feature-a"])
+  await git.branch(["branch-alpha"])
+
+  await fs.writeFile(
+    path.join(tempPath, "feature-b.js"),
+    'export const featureB = () => "B";\n'
+  )
+  await git.add(".")
+  await git.commit("Add feature B")
+  await git.branch(["feature-b"])
+
+  await fs.writeFile(
+    path.join(tempPath, "feature-c.js"),
+    'export const featureC = () => "C";\n'
+  )
+  await git.add(".")
+  await git.commit("Add feature C")
+  await git.branch(["feature-c"])
+  await git.branch(["another-branch-c"])
+
+  console.log(chalk.green("✓ Test stack created successfully!\n"))
+  console.log(chalk.bold("Location:"), chalk.yellow(tempPath))
+  console.log(chalk.bold("\nTo test:"))
+  console.log(chalk.cyan("  cd " + tempPath))
+  console.log(
+    chalk.cyan("  node /Users/wraeth/projects/lmcculloch/glu/dist/index.js ls")
+  )
+  console.log(chalk.bold("\nOr run directly:"))
+  console.log(
+    chalk.cyan(
+      `  (cd ${tempPath} && node /Users/wraeth/projects/lmcculloch/glu/dist/index.js ls)`
+    )
+  )
+  console.log(chalk.bold("\nCleanup:"))
+  console.log(chalk.cyan(`  rm -rf ${tempPath}`))
+}
+
+createTestStack().catch(console.error)


### PR DESCRIPTION
## Summary

Add developer tooling to create temporary git repositories with stacked commits for manual testing of `glu ls` without polluting the main repository.

## Changes

- [x] Added new feature
- [ ] Fixed bug
- [ ] Updated documentation
- [ ] Added tests
- [x] Updated configuration

**Details:**
- Created `scripts/create-test-stack.js` to generate temporary git repos with:
  - Multiple stacked commits ahead of origin
  - Multiple branches pointing to same commits (for testing color differentiation)
  - Proper git configuration and remote tracking setup
- Added `dev:test-stack` npm script for easy invocation

## Testing

- [x] Tests pass locally (`npm run test:run`)
- [x] Code is formatted (`npm run format:check`)
- [x] Build succeeds (`npm run build`)
- [x] Manual testing completed - script successfully creates test repos

## Notes

The script creates a temporary directory under `/tmp/glu-manual-test-*` with a pre-configured git stack. This allows developers to test `glu ls` and other commands in a realistic environment without affecting their working repository. The temp directories are automatically cleaned up on system reboot, or can be manually removed with the provided cleanup command.