### PR TITLE
fix: prune branches on glu ls that have been deleted

### DIFF
--- a/src/services/branch-service.ts
+++ b/src/services/branch-service.ts
@@ -110,4 +110,8 @@ export class BranchService {
       upstream,
     }
   }
+
+  async getAllBranches(): Promise<Branch[]> {
+    return await this.git.getAllBranches()
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #37 by pruning deleted branches from the graph storage when running `glu ls`. Now when a branch created by `glu rr` is deleted (locally or remotely), it will no longer appear in the tracking information displayed by `glu ls`.

## Changes

- [x] Fixed bug
- [x] Added tests
- [x] Updated `GitAdapter` to list all branches (local + remote)
- [x] Updated `BranchService` to expose `getAllBranches()` method
- [x] Updated `ListUseCase` to prune deleted branches before listing commits

## Implementation Details

The solution leverages the existing `GluGraphService.pruneDeletedBranches()` method that was already in the codebase but not being called. The implementation:

1. **GitAdapter** (`src/infrastructure/git-adapter.ts`):
   - Added `getAllBranches()` method that returns `Branch[]` with full metadata
   - Uses `git branch --all --format` to get both local and remote branches

2. **BranchService** (`src/services/branch-service.ts`):
   - Added `getAllBranches()` to expose the functionality through the service layer
   - Maintains clean architecture by keeping git operations in the adapter

3. **ListUseCase** (`src/use-cases/list-use-case.ts`):
   - Injected `BranchService` into the constructor
   - Calls `pruneDeletedBranches()` at the start of `execute()`
   - Removed stale branch references before displaying commit information

4. **Tests** (`tests/e2e/commands/ls.test.ts`):
   - Added test for local deleted branch pruning
   - Added test for remote deleted branch pruning
   - Both tests verify the fix for issue #37

## Testing

- [x] Tests pass locally (`npm run test:run`)
- [x] Code is formatted (`npm run format:check`)
- [x] Build succeeds (`npm run build`)
- [x] Manual testing completed

## Notes

This fix maintains the clean architecture pattern established in the codebase:
- Dependencies flow through constructors (no direct instantiation in use cases)
- Services abstract adapter operations
- Domain types (`Branch[]`) used instead of primitives where appropriate

The pruning happens automatically on every `glu ls` execution, ensuring the tracking information stays in sync with the actual branch state.